### PR TITLE
Link to documentation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -47,7 +47,7 @@
 				<div class="status" data-status>Stopped</div>
 			</div>
 			<div class="controls-right">
-				<a href="https://github.com/kylestetz/slang" class="button gray" target="docs">Docs</a>
+				<a href="https://github.com/kylestetz/slang#how-to-write-slang" class="button gray" target="docs">Docs</a>
 			</div>
 		</div>
 		<div id="editor"></div>


### PR DESCRIPTION
Add #how-to-write-slang to the documentation anchor tag. This will make it easier for non-GitHubers to find the documentation.